### PR TITLE
ランク判定と最低消費コスト書き換え機能追加（未完成）

### DIFF
--- a/Assets/Scenes/StageSelectScene.unity
+++ b/Assets/Scenes/StageSelectScene.unity
@@ -1018,6 +1018,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1475439278}
   - component: {fileID: 1475439277}
+  - component: {fileID: 1475439279}
   m_Layer: 0
   m_Name: StageManager
   m_TagString: Untagged
@@ -1059,6 +1060,18 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1475439279
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1475439276}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb44cf8893771e64baf31ea907f0713b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1615337837
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/RankJudgeAndUpdateFunction.cs
+++ b/Assets/Scripts/RankJudgeAndUpdateFunction.cs
@@ -1,0 +1,96 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class RankJudgeAndUpdateFunction : MonoBehaviour
+{
+    private int allCost = 24; //テスト用変数（総消費コスト
+    private int[,] stageRank = {{25, 50, 75, 100}, //stage1のランク基準数値
+                                {30, 60, 90, 120}, //stage2のランク基準数値
+                                {25, 50, 75, 100}, //stage3のランク基準数値
+                                {25, 50, 75, 100}, //stage4のランク基準数値
+                                {25, 50, 75, 100}, //stage5のランク基準数値
+                                {25, 50, 75, 100}, //stage6のランク基準数値
+                                {25, 50, 75, 100}, //stage7のランク基準数値
+                                {25, 50, 75, 100}, //stage8のランク基準数値
+                                {25, 50, 75, 100}, //stage9のランク基準数値
+                                {25, 50, 75, 100}, //stage10のランク基準数値
+                                }; //S~Fの判定基準
+
+    private int[] minConsumpCost = {-1, -1, -1, -1, -1,-1, -1, -1, -1, -1}; //ステージ最低消費コスト配列
+
+    private Dictionary<string, int> stageNumber = new Dictionary<string, int>() // Dictionaryクラスの宣言と初期値の設定
+    {
+        {"Stage1", 0},
+        {"Stage2", 1},
+        {"Stage3", 2},
+        {"Stage4", 3},
+        {"Stage5", 4},
+        {"Stage6", 5},
+        {"Stage7", 6},
+        {"Stage8", 7},
+        {"Stage9", 8},
+        {"Stage10", 9}
+    };
+
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        //ゴールしたら
+        if(PlayerInput.GetKeyDown(KeyCode.Alpha2))
+        {
+            JudgeAndUpdateRank(allCost);
+        }
+    }
+
+    /*最低消費コストを更新*/
+    /*public void UpdateMinConCost(int num)
+    {
+        int stage_num = stageNumber[SceneManager.GetActiveScene().name];
+        if(num < minConsumpCost[stage_num]) //今までの最低消費コストより小さければ
+        {
+            minConsumpCost[stage_num] = num; //最低消費コストを書き換え
+        }
+    }*/
+
+    /*総消費コストのランク判定と最低消費コストの書き換えをおこなう関数*/
+    public void JudgeAndUpdateRank(int num) //num == 総消費コスト
+    {
+        int stage_num = stageNumber[SceneManager.GetActiveScene().name];
+        if(num <= stageRank[stage_num, 0])
+        {
+            Debug.Log("ランク:S");
+        }
+        else if(num <= stageRank[stage_num, 1])
+        {
+            Debug.Log("ランク:A");
+        }
+        else if(num <= stageRank[stage_num, 2])
+        {
+            Debug.Log("ランク:B");
+        }
+        else if(num <= stageRank[stage_num, 3])
+        {
+            Debug.Log("ランク:C");
+        }
+        else if(num > stageRank[stage_num, 3])
+        {
+            Debug.Log("ランク:F");
+        }
+
+        //まだ書き換えされていない(minConsumpCost[stage_num] == -1) または 今までの最低消費コストより小さければ
+        if(minConsumpCost[stage_num] == -1|| num < minConsumpCost[stage_num])
+        {
+            minConsumpCost[stage_num] = num; //最低消費コストを書き換え
+            Debug.Log("ステージ" + (stage_num + 1) + "の最低消費コストが" + num + "に更新されました");
+        }
+    }
+}

--- a/Assets/Scripts/RankJudgeAndUpdateFunction.cs.meta
+++ b/Assets/Scripts/RankJudgeAndUpdateFunction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb44cf8893771e64baf31ea907f0713b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
以下未完成ポイント
・総消費コストの取得および引数への適用
・各ステージのランク基準コスト未定