### PR TITLE
総消費コストの計算とランク判定機能への適用

### DIFF
--- a/Assets/Scripts/Player/Player_Copy.cs
+++ b/Assets/Scripts/Player/Player_Copy.cs
@@ -186,7 +186,8 @@ public class Player_Copy : MonoBehaviour
             if(stageMgr.cut_erase_cost <= stageMgr.have_ene)
             {
                 stageMgr.have_ene -= stageMgr.cut_erase_cost; //コスト引く
-                Debug.Log("消すコスト(カット時):" + stageMgr.cut_erase_cost + ", " + "所持エナジー:" + stageMgr.have_ene);
+                stageMgr.all_sum_cos += stageMgr.cut_erase_cost; //総消費コストに加算
+                Debug.Log("消すコスト(カット時):" + stageMgr.cut_erase_cost + ", " + "所持エナジー:" + stageMgr.have_ene + ", " + "総消費コスト：" + stageMgr.all_sum_cos);
                 CutInCopy(_startPos, _endPos, false);
                 CutInCopyObject(cols, false);
             }

--- a/Assets/Scripts/Player/Player_Paste.cs
+++ b/Assets/Scripts/Player/Player_Paste.cs
@@ -102,9 +102,10 @@ public class Player_Paste : MonoBehaviour
 
             if(stageManager.have_ene >= (stageManager.erase_cost + stageManager.write_cost)) //所持コストから引けるなら
             {
-                Debug.Log("消えるコスト：" + stageManager.erase_cost + "," + "増やすコスト：" + stageManager.write_cost + ", " + "所持コスト：" + stageManager.have_ene);
-
                 stageManager.have_ene -= (stageManager.erase_cost + stageManager.write_cost / divide); //コスト引く
+                stageManager.all_sum_cos += (stageManager.erase_cost + stageManager.write_cost / divide); //総消費コストに加算
+                Debug.Log("消えるコスト：" + stageManager.erase_cost + "," + "増やすコスト：" + stageManager.write_cost / divide + ", " + "所持コスト：" + stageManager.have_ene);
+                Debug.Log("総消費コスト：" + stageManager.all_sum_cos);
                 CheckCost(true, mPos);
                 CheckObjectCost(true);
                 //オブジェクトをペースト

--- a/Assets/Scripts/RankJudgeAndUpdateFunction.cs
+++ b/Assets/Scripts/RankJudgeAndUpdateFunction.cs
@@ -5,7 +5,8 @@ using UnityEngine.SceneManagement;
 
 public class RankJudgeAndUpdateFunction : MonoBehaviour
 {
-    private int allCost = 24; //テスト用変数（総消費コスト
+    private StageManager stageMgr;
+    //private int allCost = 24; //テスト用変数（総消費コスト
     private int[,] stageRank = {{25, 50, 75, 100}, //stage1のランク基準数値
                                 {30, 60, 90, 120}, //stage2のランク基準数値
                                 {25, 50, 75, 100}, //stage3のランク基準数値
@@ -38,7 +39,7 @@ public class RankJudgeAndUpdateFunction : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        
+        stageMgr = FindObjectOfType<StageManager>();
     }
 
     // Update is called once per frame
@@ -47,7 +48,8 @@ public class RankJudgeAndUpdateFunction : MonoBehaviour
         //ゴールしたら
         if(PlayerInput.GetKeyDown(KeyCode.Alpha2))
         {
-            JudgeAndUpdateRank(allCost);
+            JudgeAndUpdateRank(stageMgr.all_sum_cos);
+            stageMgr.all_sum_cos = 0;
         }
     }
 

--- a/Assets/Scripts/StageManager.cs
+++ b/Assets/Scripts/StageManager.cs
@@ -22,7 +22,7 @@ public class StageManager : MonoBehaviour
     private int[] healAmount_array = {5, 10, 15, 20, 25, 30, 35, 40, 45, 50}; //ステージごとの回復速度コストの配列
     private int stage = 0; //0=ステージ1
     public int have_ene = 10000; //初期コスト
-    private int all_sum_cos = 0; //ステージで消費した全てのコスト
+    public int all_sum_cos = 0; //ステージで消費した全てのコスト
     public int erase_cost = 0; //貼り付け箇所の消すコスト
     public int write_cost = 0; //取得箇所の増やすコスト
     public int cut_erase_cost = 0; //カットの時のみの取得箇所の消すコスト


### PR DESCRIPTION
２ボタンを押すと判定がされる（総消費コストがリセット）
Scene名がStage1やStage2になっていないと判定不可