### PR TITLE
長いオブジェクトに対する接地判定追加

### DIFF
--- a/Assets/Resources/Prefabs/Object/Bar-L.prefab
+++ b/Assets/Resources/Prefabs/Object/Bar-L.prefab
@@ -1,75 +1,160 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &7894212698863154771
-PrefabInstance:
+--- !u!1 &4550408371338664941
+GameObject:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6378496011443260484}
+  - component: {fileID: 5661261083072354595}
+  - component: {fileID: 213782490174500390}
+  - component: {fileID: 2479240798657945899}
+  m_Layer: 7
+  m_Name: Bar-L
+  m_TagString: Bar-L
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6378496011443260484
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4550408371338664941}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 501075901548203632, guid: 76a4898235411aa45a7c7268cd42de6b, type: 3}
-      propertyPath: m_Mass
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1998025880269059254, guid: 76a4898235411aa45a7c7268cd42de6b, type: 3}
-      propertyPath: m_Name
-      value: Bar-L
-      objectReference: {fileID: 0}
-    - target: {fileID: 1998025880269059254, guid: 76a4898235411aa45a7c7268cd42de6b, type: 3}
-      propertyPath: m_TagString
-      value: Bar-L
-      objectReference: {fileID: 0}
-    - target: {fileID: 8942141072850674463, guid: 76a4898235411aa45a7c7268cd42de6b, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8942141072850674463, guid: 76a4898235411aa45a7c7268cd42de6b, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.6
-      objectReference: {fileID: 0}
-    - target: {fileID: 8942141072850674463, guid: 76a4898235411aa45a7c7268cd42de6b, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 5.376972
-      objectReference: {fileID: 0}
-    - target: {fileID: 8942141072850674463, guid: 76a4898235411aa45a7c7268cd42de6b, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.47707084
-      objectReference: {fileID: 0}
-    - target: {fileID: 8942141072850674463, guid: 76a4898235411aa45a7c7268cd42de6b, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8942141072850674463, guid: 76a4898235411aa45a7c7268cd42de6b, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8942141072850674463, guid: 76a4898235411aa45a7c7268cd42de6b, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8942141072850674463, guid: 76a4898235411aa45a7c7268cd42de6b, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8942141072850674463, guid: 76a4898235411aa45a7c7268cd42de6b, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8942141072850674463, guid: 76a4898235411aa45a7c7268cd42de6b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8942141072850674463, guid: 76a4898235411aa45a7c7268cd42de6b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8942141072850674463, guid: 76a4898235411aa45a7c7268cd42de6b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 76a4898235411aa45a7c7268cd42de6b, type: 3}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 106.1128, y: 4.1, z: 0}
+  m_LocalScale: {x: 3, y: 0.64, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &5661261083072354595
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4550408371338664941}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 509548093
+  m_SortingLayer: -4
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 72bf2b108a750be48b71ff99afbdbc25, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!61 &213782490174500390
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4550408371338664941}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.021053076, y: -0.021053314}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 7.5, y: 2.5}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 7, y: 1.55}
+  m_EdgeRadius: 0
+--- !u!50 &2479240798657945899
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4550408371338664941}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 5
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0

--- a/Assets/Resources/Prefabs/Object/Bar-L.prefab.meta
+++ b/Assets/Resources/Prefabs/Object/Bar-L.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4e1f7a0c91675024485149b0c0d6f414
+guid: abda40439fb799a4f8b7e3dced8ee53c
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Resources/Prefabs/Object/Bar-M.prefab
+++ b/Assets/Resources/Prefabs/Object/Bar-M.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 7641750173817173624}
   - component: {fileID: 2768490789832950141}
   - component: {fileID: 501075901548203632}
-  m_Layer: 3
+  m_Layer: 7
   m_Name: Bar-M
   m_TagString: Bar-M
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Prefabs/Object/Needleball.prefab
+++ b/Assets/Resources/Prefabs/Object/Needleball.prefab
@@ -194,7 +194,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4831830149815093592}
   - component: {fileID: 1633714351845959316}
-  m_Layer: 0
+  m_Layer: 3
   m_Name: Needleball
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Prefabs/Object/Rotate_Center_S.prefab
+++ b/Assets/Resources/Prefabs/Object/Rotate_Center_S.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 6287085634661312183}
   - component: {fileID: 247534162469598162}
   - component: {fileID: 713943231380744002}
-  m_Layer: 3
+  m_Layer: 7
   m_Name: Rotate_Center_S
   m_TagString: Rotate_Center_S
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Prefabs/Object/Rotate_Edge_L.prefab
+++ b/Assets/Resources/Prefabs/Object/Rotate_Edge_L.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7307756154272188096}
   - component: {fileID: 6377307459455571342}
-  m_Layer: 3
+  m_Layer: 7
   m_Name: rotateE_L
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Prefabs/Object/Rotate_Edge_M.prefab
+++ b/Assets/Resources/Prefabs/Object/Rotate_Edge_M.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 417975819300186020}
   - component: {fileID: 3097496035959672348}
-  m_Layer: 3
+  m_Layer: 7
   m_Name: rotateE_M
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Prefabs/Object/Rotate_Edge_S.prefab
+++ b/Assets/Resources/Prefabs/Object/Rotate_Edge_S.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 7405145732190165075}
   - component: {fileID: 808403592605968956}
   - component: {fileID: 615785175101146968}
-  m_Layer: 3
+  m_Layer: 7
   m_Name: Rotate_Edge_S
   m_TagString: Rotate_Edge_S
   m_Icon: {fileID: 0}
@@ -157,7 +157,7 @@ GameObject:
   m_Component:
   - component: {fileID: 473449499814859824}
   - component: {fileID: 1739336513611190090}
-  m_Layer: 3
+  m_Layer: 7
   m_Name: rotateE_S
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -242,7 +242,7 @@ GameObject:
   - component: {fileID: 1510813466748078294}
   - component: {fileID: 8447817928130283066}
   - component: {fileID: 170862480500837856}
-  m_Layer: 3
+  m_Layer: 7
   m_Name: Square
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Prefabs/Object/VanishFloor.prefab
+++ b/Assets/Resources/Prefabs/Object/VanishFloor.prefab
@@ -144,4 +144,3 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   stayTime: 2
-  elapsed: 0

--- a/Assets/Resources/Prefabs/Object/door 1.prefab
+++ b/Assets/Resources/Prefabs/Object/door 1.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 7965379154160549734}
   - component: {fileID: 5542295973266396634}
   - component: {fileID: 9016092672927213838}
-  m_Layer: 0
+  m_Layer: 3
   m_Name: door 1
   m_TagString: WarpDoor
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Prefabs/Player.prefab
+++ b/Assets/Resources/Prefabs/Player.prefab
@@ -131,11 +131,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   moveSpeed: 10
   jumpForce: 15
-  groundCheckDistance: 1.7
+  groundCheckDistance: 1.5
+  objectCheckDistance: 1.05
   maxHoldTime: 0.2
   groundLayer:
     serializedVersion: 2
     m_Bits: 8
+  longobjectLayer:
+    serializedVersion: 2
+    m_Bits: 128
 --- !u!114 &2660686992821530170
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player/Player_Move.cs
+++ b/Assets/Scripts/Player/Player_Move.cs
@@ -16,8 +16,10 @@ public class Player_Move : MonoBehaviour
     [SerializeField] float moveSpeed = 1.0f;
     [SerializeField] float jumpForce = 5f;
     [SerializeField] float groundCheckDistance = 0.1f;
+    [SerializeField] float objectCheckDistance = 0.1f;
     [SerializeField] float maxHoldTime = 0.2f;          // 追加ジャンプ力を加える最大時間（秒）
     [SerializeField] LayerMask groundLayer;
+    [SerializeField] LayerMask longobjectLayer;
 
     private Rigidbody2D rb; 
     private bool isJumping = false;
@@ -91,14 +93,22 @@ public class Player_Move : MonoBehaviour
     bool IsGrounded()
     {
         Vector3 pos = this.transform.position;
-        Vector3 dif = new Vector3(0.45f, 0, 0);
-        RaycastHit2D hit = Physics2D.Raycast(pos, Vector2.down, groundCheckDistance, groundLayer);
-        RaycastHit2D hitR = Physics2D.Raycast(pos+dif, Vector2.down, groundCheckDistance, groundLayer);
-        RaycastHit2D hitL = Physics2D.Raycast(pos-dif, Vector2.down, groundCheckDistance, groundLayer);
+        Vector3 dif = new Vector3(0.35f, 0, 0);
+        Vector3 dif_Lobj = new Vector3(0.05f, 0, 0);
+        RaycastHit2D hit_T = Physics2D.Raycast(pos, Vector2.down, groundCheckDistance, groundLayer);
+        RaycastHit2D hitR_T = Physics2D.Raycast(pos+ dif, Vector2.down, groundCheckDistance, groundLayer);
+        RaycastHit2D hitL_T = Physics2D.Raycast(pos- dif, Vector2.down, groundCheckDistance, groundLayer);
         Debug.DrawRay(pos, Vector2.down * groundCheckDistance, Color.red);
-        Debug.DrawRay(pos+dif, Vector2.down * groundCheckDistance, Color.red);
-        Debug.DrawRay(pos-dif, Vector2.down * groundCheckDistance, Color.red);
+        Debug.DrawRay(pos+ dif, Vector2.down * groundCheckDistance, Color.red);
+        Debug.DrawRay(pos- dif, Vector2.down * groundCheckDistance, Color.red);
+
+        RaycastHit2D hit_O = Physics2D.Raycast(pos, Vector2.down, objectCheckDistance, longobjectLayer);
+        RaycastHit2D hitR_O = Physics2D.Raycast(pos + dif_Lobj, Vector2.down, objectCheckDistance, longobjectLayer);
+        RaycastHit2D hitL_O = Physics2D.Raycast(pos - dif_Lobj, Vector2.down, objectCheckDistance, longobjectLayer);
+        Debug.DrawRay(pos, Vector2.down * objectCheckDistance, Color.blue);
+        Debug.DrawRay(pos + dif_Lobj, Vector2.down * objectCheckDistance, Color.blue);
+        Debug.DrawRay(pos - dif_Lobj, Vector2.down * objectCheckDistance, Color.blue);
         //Debug.Log("hit" + hit.collider);
-        return hit.collider != null || hitR.collider != null || hitL.collider != null;
+        return rb.velocity.y <= 0.5f && (hit_T.collider != null || hitR_T.collider != null || hitL_T.collider != null || hit_O.collider != null || hitR_O.collider != null || hitL_O.collider != null);//y方向の速度が下向き（または停止）を追加
     }
 }


### PR DESCRIPTION
長いオブジェクトにのみ使われる設置判定を新たに追加しました。これによって、壁のぼりを解決しました。　ペースト時にレイヤーがgroundになってしまう問題を解決したら完全解決します