### PR TITLE
﻿回復アイテム追加 ランク判定にHP追加 key_lockをプレハブ化

### DIFF
--- a/Assets/Object Scriptable Object.asset
+++ b/Assets/Object Scriptable Object.asset
@@ -141,3 +141,11 @@ MonoBehaviour:
     obj: {fileID: 4191004688952013668, guid: c58aa3cdd033f6048ac5af044845fee5, type: 3}
     p_ene: 20
     ow_ene: 10
+  - name: HPHeal
+    obj: {fileID: 2210278136747466567, guid: 847b5c78846ccb045a30083b60fa1306, type: 3}
+    p_ene: 20
+    ow_ene: 0
+  - name: key_lock
+    obj: {fileID: 452536124641921469, guid: 4a7f36a9583bbc643950bfaedb40bffb, type: 3}
+    p_ene: 500
+    ow_ene: 0

--- a/Assets/Resources/Prefabs/Object/HPHeal.prefab
+++ b/Assets/Resources/Prefabs/Object/HPHeal.prefab
@@ -1,0 +1,146 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2210278136747466567
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2703626733371949805}
+  - component: {fileID: 8850039619251457822}
+  - component: {fileID: 7288320271470248712}
+  - component: {fileID: 118295822630031225}
+  m_Layer: 0
+  m_Name: HPHeal
+  m_TagString: HPHeal
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2703626733371949805
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2210278136747466567}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3.223, y: -5.83, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &8850039619251457822
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2210278136747466567}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: fcb6306ea84584c48be212267656098b, type: 3}
+  m_Color: {r: 1, g: 0, b: 0.9427595, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.28, y: 1.28}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!61 &7288320271470248712
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2210278136747466567}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -0.06, y: 0.07}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1.28, y: 1.28}
+    newSize: {x: 1.28, y: 1.28}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.6, y: 1}
+  m_EdgeRadius: 0
+--- !u!114 &118295822630031225
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2210278136747466567}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2b483e44d2256944a1d4a181dcef741, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Healamount: 10

--- a/Assets/Resources/Prefabs/Object/HPHeal.prefab.meta
+++ b/Assets/Resources/Prefabs/Object/HPHeal.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 847b5c78846ccb045a30083b60fa1306
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Prefabs/Object/Needle-M.prefab
+++ b/Assets/Resources/Prefabs/Object/Needle-M.prefab
@@ -229,7 +229,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 051f2fdcf8e66f646a57e8ca6a9a42e1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  togeDamage: 5
+  togeDamage: 40
 --- !u!61 &-5891703234652050589
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Object/Needle.prefab
+++ b/Assets/Resources/Prefabs/Object/Needle.prefab
@@ -229,7 +229,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 051f2fdcf8e66f646a57e8ca6a9a42e1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  togeDamage: 5
+  togeDamage: 40
 --- !u!61 &1138818455429591929
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Object/Needleball.prefab
+++ b/Assets/Resources/Prefabs/Object/Needleball.prefab
@@ -100,7 +100,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 051f2fdcf8e66f646a57e8ca6a9a42e1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  togeDamage: 5
+  togeDamage: 40
 --- !u!50 &5471130656243168931
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/Resources/Prefabs/Object/key_lock.prefab
+++ b/Assets/Resources/Prefabs/Object/key_lock.prefab
@@ -1,0 +1,173 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &452536124641921469
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9081950037084421425}
+  - component: {fileID: 9216239089661250431}
+  - component: {fileID: 7089952329043251676}
+  - component: {fileID: 8465470910915446482}
+  - component: {fileID: 8004327611469203049}
+  m_Layer: 0
+  m_Name: key_lock
+  m_TagString: key_lock
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9081950037084421425
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 452536124641921469}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4, y: -5.83, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &9216239089661250431
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 452536124641921469}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 9e0714dd0c2d70d46b78c0e919c50c6e, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.28, y: 1.28}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!61 &7089952329043251676
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 452536124641921469}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -0.071585596, y: 0.018568516}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1.28, y: 1.28}
+    newSize: {x: 1.28, y: 1.28}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.5381907, y: 1.1451335}
+  m_EdgeRadius: 0
+--- !u!114 &8465470910915446482
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 452536124641921469}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0efea2480d390cb40b8ee7eea85514d7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!50 &8004327611469203049
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 452536124641921469}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0

--- a/Assets/Resources/Prefabs/Object/key_lock.prefab.meta
+++ b/Assets/Resources/Prefabs/Object/key_lock.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4a7f36a9583bbc643950bfaedb40bffb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/StageSelectScene.unity
+++ b/Assets/Scenes/StageSelectScene.unity
@@ -2308,46 +2308,6 @@ RectTransform:
   m_AnchoredPosition: {x: 20, y: -175}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0, y: 1}
---- !u!1 &1236940938 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3807169329540211649, guid: dcdd389a34128a048b2e112fe01cdd5f, type: 3}
-  m_PrefabInstance: {fileID: 2602327985525169769}
-  m_PrefabAsset: {fileID: 0}
---- !u!70 &1236940947
-CapsuleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1236940938}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_Size: {x: 1, y: 1}
-  m_Direction: 0
 --- !u!1 &1278022660
 GameObject:
   m_ObjectHideFlags: 0
@@ -2664,13 +2624,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   player_HP: 100
+  player_MAXHP: 100
   isPlayerDamaged: 0
   switch_state: 0
   key_lock_state: 0
+  switch_key_states: []
   costHeal_timeOut: 0
   stageNum: -1
   initAddCost_EachStage: 00000000000000000000000000000000000000000000000000000000000000000000000000000000
-  have_ene: 100000
+  have_ene: 200000
   all_sum_cos: 0
   erase_cost: 0
   write_cost: 0
@@ -11478,11 +11440,11 @@ PrefabInstance:
       objectReference: {fileID: 1475439277}
     - target: {fileID: 3588919106790919407, guid: dcdd389a34128a048b2e112fe01cdd5f, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -33.56
+      value: -35.32
       objectReference: {fileID: 0}
     - target: {fileID: 3588919106790919407, guid: dcdd389a34128a048b2e112fe01cdd5f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -4.11
+      value: -3.25
       objectReference: {fileID: 0}
     - target: {fileID: 3588919106790919407, guid: dcdd389a34128a048b2e112fe01cdd5f, type: 3}
       propertyPath: m_LocalPosition.z
@@ -11564,10 +11526,7 @@ PrefabInstance:
     - {fileID: 8709870156297503356, guid: dcdd389a34128a048b2e112fe01cdd5f, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3807169329540211649, guid: dcdd389a34128a048b2e112fe01cdd5f, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1236940947}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dcdd389a34128a048b2e112fe01cdd5f, type: 3}
 --- !u!1001 &3280173084595662182
 PrefabInstance:

--- a/Assets/Scenes/nagasawatest/others/balltest.unity
+++ b/Assets/Scenes/nagasawatest/others/balltest.unity
@@ -24741,149 +24741,6 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
---- !u!1 &1015705517
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1015705521}
-  - component: {fileID: 1015705520}
-  - component: {fileID: 1015705519}
-  - component: {fileID: 1015705518}
-  m_Layer: 0
-  m_Name: key_lock
-  m_TagString: key_lock
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1015705518
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1015705517}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0efea2480d390cb40b8ee7eea85514d7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!61 &1015705519
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1015705517}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: -0.06474459, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1.28, y: 1.28}
-    newSize: {x: 1.28, y: 1.28}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.6613295, y: 1.28}
-  m_EdgeRadius: 0
---- !u!212 &1015705520
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1015705517}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 9e0714dd0c2d70d46b78c0e919c50c6e, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1.28, y: 1.28}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &1015705521
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1015705517}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 4, y: -5.83, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1025842520
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -25123,8 +24980,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   player_HP: 100
+  player_MAXHP: 100
+  isPlayerDamaged: 0
   switch_state: 0
   key_lock_state: 0
+  switch_key_states: []
   costHeal_timeOut: 0
   stageNum: -1
   initAddCost_EachStage: 00000000000000000000000000000000000000000000000000000000000000000000000000000000
@@ -27181,6 +27041,124 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 1920, y: 1080}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1001 &5563026567714233155
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 452536124641921469, guid: 4a7f36a9583bbc643950bfaedb40bffb, type: 3}
+      propertyPath: m_Name
+      value: key_lock
+      objectReference: {fileID: 0}
+    - target: {fileID: 9081950037084421425, guid: 4a7f36a9583bbc643950bfaedb40bffb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 9081950037084421425, guid: 4a7f36a9583bbc643950bfaedb40bffb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.83
+      objectReference: {fileID: 0}
+    - target: {fileID: 9081950037084421425, guid: 4a7f36a9583bbc643950bfaedb40bffb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9081950037084421425, guid: 4a7f36a9583bbc643950bfaedb40bffb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9081950037084421425, guid: 4a7f36a9583bbc643950bfaedb40bffb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9081950037084421425, guid: 4a7f36a9583bbc643950bfaedb40bffb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9081950037084421425, guid: 4a7f36a9583bbc643950bfaedb40bffb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9081950037084421425, guid: 4a7f36a9583bbc643950bfaedb40bffb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9081950037084421425, guid: 4a7f36a9583bbc643950bfaedb40bffb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9081950037084421425, guid: 4a7f36a9583bbc643950bfaedb40bffb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4a7f36a9583bbc643950bfaedb40bffb, type: 3}
+--- !u!1001 &5690870508458452360
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2210278136747466567, guid: 847b5c78846ccb045a30083b60fa1306, type: 3}
+      propertyPath: m_Name
+      value: HPHeal
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703626733371949805, guid: 847b5c78846ccb045a30083b60fa1306, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703626733371949805, guid: 847b5c78846ccb045a30083b60fa1306, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.83
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703626733371949805, guid: 847b5c78846ccb045a30083b60fa1306, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703626733371949805, guid: 847b5c78846ccb045a30083b60fa1306, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703626733371949805, guid: 847b5c78846ccb045a30083b60fa1306, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703626733371949805, guid: 847b5c78846ccb045a30083b60fa1306, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703626733371949805, guid: 847b5c78846ccb045a30083b60fa1306, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703626733371949805, guid: 847b5c78846ccb045a30083b60fa1306, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703626733371949805, guid: 847b5c78846ccb045a30083b60fa1306, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2703626733371949805, guid: 847b5c78846ccb045a30083b60fa1306, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7288320271470248712, guid: 847b5c78846ccb045a30083b60fa1306, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 847b5c78846ccb045a30083b60fa1306, type: 3}
 --- !u!224 &5780904307351357361
 RectTransform:
   m_ObjectHideFlags: 0
@@ -27470,4 +27448,5 @@ SceneRoots:
   - {fileID: 1970284899}
   - {fileID: 1063824774}
   - {fileID: 479934784}
-  - {fileID: 1015705521}
+  - {fileID: 5563026567714233155}
+  - {fileID: 5690870508458452360}

--- a/Assets/Scripts/Items/HealItemScript.cs
+++ b/Assets/Scripts/Items/HealItemScript.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class HealItemScript : MonoBehaviour
+{
+    private StageManager stageManager;
+    public int Healamount = 10;
+
+    void Start()
+    {
+        stageManager = FindObjectOfType<StageManager>();
+
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (stageManager.player_HP + Healamount <= stageManager.player_MAXHP)
+        {
+            stageManager.player_HP += Healamount;
+            Debug.Log(Healamount + "‰ñ•œ");
+        }
+        else
+        {
+            stageManager.player_HP = stageManager.player_MAXHP;
+        }
+
+
+        Destroy(this.gameObject);
+    }
+}

--- a/Assets/Scripts/Items/HealItemScript.cs.meta
+++ b/Assets/Scripts/Items/HealItemScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2b483e44d2256944a1d4a181dcef741
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Items/KeyScript.cs
+++ b/Assets/Scripts/Items/KeyScript.cs
@@ -9,12 +9,17 @@ public class KeyLockScript : MonoBehaviour
     void Start()
     {
         stageManager = FindObjectOfType<StageManager>();
-        stageManager.key_lock_state = false;
+        //stageManager.key_lock_state = false;
     }
 
     private void OnTriggerEnter2D(Collider2D other)
     {
-        stageManager.key_lock_state = true;
-        Destroy(this.gameObject);
+
+        if (other.gameObject.CompareTag("Player")) // "Player"タグのオブジェクトと衝突したら
+        {
+            stageManager.key_lock_state = true;
+            Destroy(this.gameObject);
+        }
+
     }
 }

--- a/Assets/Scripts/RankJudgeAndUpdateFunction.cs
+++ b/Assets/Scripts/RankJudgeAndUpdateFunction.cs
@@ -79,7 +79,7 @@ public class RankJudgeAndUpdateFunction : MonoBehaviour
         {
             if ((clearFunc.GetisClear()  && !hasJudged))
             {
-                JudgeAndUpdateRank(stageMgr.all_sum_cos,true);
+                JudgeAndUpdateRank(stageMgr.all_sum_cos-stageMgr.player_HP, true);
                 //stageMgr.all_sum_cos = 0;
                 rankDisplay.SetText(rankText);
                 rankDisplay.InitTextSize(); 
@@ -111,7 +111,7 @@ public class RankJudgeAndUpdateFunction : MonoBehaviour
         int nowCost = 0;
         if (stageMgr != null)
         {
-            nowCost = stageMgr.all_sum_cos; //総消費コスト
+            nowCost = stageMgr.all_sum_cos - stageMgr.player_HP; //総消費コスト
         }
         int stage_num = 0;          //ステージナンバーは0で初期化。もしデバッグ用ステージだったらstage1のコストを流用
         if (Regex.IsMatch(SceneManager.GetActiveScene().name, @"^Stage\d+$")) //シーン名がStageなんとかなら

--- a/Assets/Scripts/StageManager.cs
+++ b/Assets/Scripts/StageManager.cs
@@ -17,6 +17,7 @@ public class StageManager : MonoBehaviour
     Player_Function playerFunc;
     RankJudgeAndUpdateFunction rankFunc;
     public int player_HP = 100;
+    public int player_MAXHP = 100;
     public bool isPlayerDamaged = false;
     private float noDamageTime = 1.0f;
     private float nowNoDanageTime = 0.0f;

--- a/Assets/Scripts/UI/GameUIController.cs
+++ b/Assets/Scripts/UI/GameUIController.cs
@@ -33,7 +33,7 @@ public class GameUIController : MonoBehaviour
         text_nowCost.text = "nowCost\n:" + stageManager.have_ene;
         //ジャッジする関数を持ってきてる。2つ目の変数は絶対にfalse。
         //2つ目の変数をtrueにすると最小消費コストが更新され、既にジャッジが終わったと判定される
-        text_nowRank.text = judgeFunc.JudgeAndUpdateRank(stageManager.all_sum_cos, false);
+        text_nowRank.text = judgeFunc.JudgeAndUpdateRank(stageManager.all_sum_cos - stageManager.player_HP, false);
         text_nextRank.text = "next Rank ... left " + judgeFunc.culcCostToNextRank();
     }
 }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -46,6 +46,7 @@ TagManager:
   - Needleball
   - weight
   - VanishFloor
+  - HPHeal
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
﻿・回復アイテム追加
StageManager.csにint player_MAXHP を追加
HealItemScript.csを追加（内容はKeyScriptとほとんど同じ）

・ランク判定にHP追加
JudgeAndUpdateRankの引数を全てstageManager.all_sum_cos - stageManager.player_HPに書き換え

・key_lockをプレハブ化、オブジェクトスクリプタブルに追加
なんも変更加えてないから動くかどうかわからん
・key_lockにRigidbody追加、playerに触れた時にstageManager.key_lock_state = true;
 Destroy(this.gameObject);するように変更